### PR TITLE
load and dump to a binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ priv/
 _build/
 /deps/
 /doc/
+.dialyzer.plt

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,14 @@
+-*- mode: text -*-
+
+v0.0.4
+  * dump and load using binaries
+  * magick attribute is read-write
+
+v0.0.3
+  * crop function
+
+v0.0.2
+  * thumbnail and scale functions
+
+v0.0.1
+  * first version

--- a/automation/test
+++ b/automation/test
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+export HOME="$WORKSPACE"
+
+with-session() {
+  while read; do echo -e "\e[0;32m$@\e[0m: $REPLY"; done
+  echo
+}
+
+{
+  [ -r "$WORKSPACE/.mix/rebar" ]                  || { echo y | mix local.rebar; }
+  [ -r "$WORKSPACE/.mix/archives/hex-0.10.4.ez" ] || { echo y | mix local.hex; }
+  mix deps.get
+  [ -r "$DIALYZER_PLT" ] || mix dialyzer.plt
+} | with-session "dependencies"
+
+mix compile | with-session "compilation"
+
+mix dialyzer --halt-exit-status | with-session "dialyzer"
+
+mix test | with-session "test"
+

--- a/lib/exmagick.ex
+++ b/lib/exmagick.ex
@@ -97,6 +97,8 @@ defmodule ExMagick do
         set_attr(handle, attribute, value)
       :density when is_binary(value) ->
         set_attr(handle, attribute, value)
+      :magick  when is_binary(value) ->
+        set_attr(handle, attribute, value)
       _ ->
         {:error, "unknown attribute #{attribute}"}
     end
@@ -211,11 +213,13 @@ defmodule ExMagick do
     handle
   end
 
-  @spec image_load(image, Path.t) :: {:ok, image} | {:error, reason :: term}
+  @spec image_load(image, Path.t | {:blob, binary}) :: {:ok, image} | {:error, reason :: term}
   @doc """
-  Loads into the handler an image from a file.
+  Loads an image into the handler. You may provide a file path or a
+  tuple `{:blob, ...}` which the second argument is the blob to load.
   """
-  def image_load(_handle, _path), do: fail
+  def image_load(handle, {:blob, blob}), do: image_load_blob(handle, blob)
+  def image_load(handle, path), do: image_load_file(handle, path)
 
   @spec image_dump!(image, Path.t) :: image
   def image_dump!(handle, path) do
@@ -230,7 +234,32 @@ defmodule ExMagick do
   If the attr `:adjoin` is `false`, multiple files will be created and the
   filename is expected to have a printf-formatting sytle (ex.: `foo%0d.png`).
   """
-  def image_dump(_handle, _path), do: fail
+  def image_dump(handle, path), do: image_dump_file(handle, path)
+
+  @spec image_dump(image) :: {:ok, binary} | {:error, reason :: term}
+  @doc """
+  Returns the image as a binary. You can change the type of this image
+  using the `:magick` attribute.
+  """
+  def image_dump(handle), do: image_dump_blob(handle)
+
+  @spec image_dump!(image) :: binary | {:error, reason :: term}
+  def image_dump!(handle) do
+    {:ok, blob} = image_dump(handle)
+    blob
+  end
+
+  @spec image_load_file(image, Path.t) :: {:ok, image} | {:error, reason :: term}
+  defp image_load_file(_handle, _path), do: fail
+
+  @spec image_load_blob(image, binary) :: {:ok, image} | {:error, reason :: term}
+  defp image_load_blob(_handle, _blob), do: fail
+
+  @spec image_dump_file(image, Path.t) :: {:ok, image} | {:error, reason :: term}
+  defp image_dump_file(_handle, _path), do: fail
+
+  @spec image_dump_blob(image) :: {:ok, binary} | {:error, reason :: term}
+  defp image_dump_blob(_handle), do: fail
 
   @spec set_attr(image, atom, term) :: {:ok, image} | {:error, reason :: term}
   defp set_attr(_handle, _attribute, _value), do: fail

--- a/lib/exmagick.ex
+++ b/lib/exmagick.ex
@@ -62,35 +62,41 @@ defmodule ExMagick do
   """
 
   @typedoc """
-  A handle used by the GraphicsMagick API
-
-  It's internal structure should never be assumed, instead, it should be used
-  with this module's functions
+  An opaque handle used by the GraphicsMagick API
   """
-  @opaque image :: <<>>
+  @opaque handle  :: binary
+
+  @type exm_error :: {:error, String.t}
 
   @on_load {:load, 0}
-  @spec load() :: no_return
+
   @doc false
+  @spec load :: :ok | {:error, {atom, charlist}}
   def load do
     sofile = Path.join([:code.priv_dir(:exmagick), "lib", "libexmagick"])
+    |> String.to_charlist
     :erlang.load_nif(sofile, 0)
   end
 
-  @spec attr!(image, atom, term) :: image
+  @doc """
+  Refer to `attr/3`
+  """
+  @spec attr!(handle, :atom, String.t | boolean) :: handle
   def attr!(handle, attribute, value) do
     {:ok, handle} = attr(handle, attribute, value)
     handle
   end
 
-  @spec attr(image, atom, term) :: {:ok, image} | {:error, reason :: term}
   @doc """
   Changes image `attribute`s.
 
   Currently the following `attribute`s are available:
   * `:adjoin` (defaults to `true`) - set to `false` to produce different images
   for each frame;
+  * `:magick` - the image type [ex.: PNG]
+  * `:density` - horizontal and vertical resolution in pixels of this image; [default: 72]
   """
+  @spec attr(handle, :atom, String.t | boolean) :: {:ok, handle} | exm_error
   def attr(handle, attribute, value) when is_atom(attribute) do
     case attribute do
       :adjoin when is_boolean(value) ->
@@ -104,32 +110,39 @@ defmodule ExMagick do
     end
   end
 
-  @spec attr!(image, atom) :: image
+  @doc """
+  Refer to `attr/2`
+  """
+  @spec attr!(handle, atom) :: String.t | boolean | non_neg_integer
   def attr!(handle, attribute) do
     {:ok, handle} = attr(handle, attribute)
     handle
   end
 
-  @spec attr(image, atom) :: {:ok, attr_value :: term} | {:error, reason :: term}
   @doc """
-  Queries `attribute` on image.
+  Queries `attribute` on image. Refer to `attr/3` for more information.
 
-  In addition to the attributess defined in `attr/3`, the following are
-  available:
-  * `:magick` - Image encoding format (e.g. "GIF");
+  In addition to `attr/3` the following attributes are defined:
+
+  * `:rows` The horizontal size in pixels of the image
+  * `:columns` The vertical size in pixels of the image
   """
+  @spec attr(handle, atom) :: {:ok, String.t | boolean | non_neg_integer} | exm_error
   def attr(handle, attribute), do: get_attr(handle, attribute)
 
-  @spec size!(image) :: %{height: pos_integer, width: pos_integer}
+  @doc """
+  Refer to `size/1`.
+  """
+  @spec size!(handle) :: %{width: non_neg_integer, height: non_neg_integer}
   def size!(handle) do
     {:ok, image_size} = size(handle)
     image_size
   end
 
-  @spec size(image) :: {:ok, %{height: pos_integer, width: pos_integer}}
   @doc """
   Queries the image size
   """
+  @spec size(handle) :: {:ok, %{width: non_neg_integer, height: non_neg_integer}} | exm_error
   def size(handle) do
     with \
       {:ok, width}  <- attr(handle, :columns),
@@ -139,46 +152,51 @@ defmodule ExMagick do
     end
   end
 
-  @spec size!(image, pos_integer, pos_integer) :: image
+  @doc """
+  Refer to `size/3`
+  """
+  @spec size!(handle, non_neg_integer, non_neg_integer) :: handle
   def size!(handle, width, height) do
     {:ok, handle} = size(handle, width, height)
     handle
   end
 
-  @spec size(image, pos_integer, pos_integer) :: {:ok, image} | {:error, reason :: term}
   @doc """
   Resizes the image.
   """
+  @spec size(handle, non_neg_integer, non_neg_integer) :: {:ok, handle} | exm_error
   def size(_handle, _width, _height), do: fail
 
-  @spec crop!(image, non_neg_integer, non_neg_integer, non_neg_integer, non_neg_integer) :: image
+  @doc """
+  Refer to `crop/5`.
+  """
+  @spec crop!(handle, non_neg_integer, non_neg_integer, non_neg_integer, non_neg_integer) :: handle
   def crop!(handle, x, y, width, height) do
     {:ok, handle} = crop(handle, x, y, width, height)
     handle
   end
 
-  @spec crop(image, non_neg_integer, non_neg_integer, non_neg_integer, non_neg_integer) :: {:ok, image} | {:error, reason :: term}
   @doc """
   Crops the image.
 
-  * x,y refer to starting point, where (0,0) is top left
+  * `x`, `y` refer to starting point, where (0, 0) is top left
   """
+  @spec crop(handle, non_neg_integer, non_neg_integer, non_neg_integer, non_neg_integer) :: {:ok, handle} | exm_error
   def crop(_handle, _x, _y, _width, _height), do: fail
 
-
-  @spec thumb!(image, pos_integer, pos_integer) :: image
+  @spec thumb!(handle, non_neg_integer, non_neg_integer) :: handle
   def thumb!(handle, width, height) do
     {:ok, handle} = thumb(handle, width, height)
     handle
   end
 
-  @spec thumb(image, pos_integer, pos_integer) :: {:ok, image} | {:error, reason :: term}
   @doc """
   Generates a thumbnail for image.
 
   _Note that this method resizes the image as quickly as possible, with more
   concern for speed than resulting image quality._
   """
+  @spec thumb(handle, non_neg_integer, non_neg_integer) :: {:ok, handle} | exm_error
   def thumb(_handle, _width, _height), do: fail
 
   @doc false
@@ -193,79 +211,93 @@ defmodule ExMagick do
     init
   end
 
-  @spec init!() :: image
+  @doc """
+  Refer to `init/0`
+  """
+  @spec init! :: handle
   def init! do
     {:ok, handle} = init()
     handle
   end
 
-  @spec init() :: {:ok, image} | {:error, reason :: term}
   @doc """
   Creates a new image handle with default values.
 
-  Image attributes may be tuned by using the `attr/2` function.
+  Image attributes may be tuned by using the `attr/3` function.
   """
   def init, do: fail
 
-  @spec image_load!(image, Path.t) :: image
-  def image_load!(handle, path) do
-    {:ok, handle} = image_load(handle, path)
+  @doc """
+  Refer to `image_load!/2`
+  """
+  @spec image_load!(handle, Path.t | {:blob, binary}) :: handle
+  def image_load!(handle, path_or_blob) do
+    {:ok, handle} = image_load(handle, path_or_blob)
     handle
   end
 
-  @spec image_load(image, Path.t | {:blob, binary}) :: {:ok, image} | {:error, reason :: term}
   @doc """
   Loads an image into the handler. You may provide a file path or a
   tuple `{:blob, ...}` which the second argument is the blob to load.
   """
+  @spec image_load(handle, Path.t | {:blob, binary}) :: {:ok, handle} | exm_error
   def image_load(handle, {:blob, blob}), do: image_load_blob(handle, blob)
   def image_load(handle, path), do: image_load_file(handle, path)
 
-  @spec image_dump!(image, Path.t) :: image
+  @doc """
+  Refer to `image_dump/2`
+  """
+  @spec image_dump!(handle, Path.t) :: handle
   def image_dump!(handle, path) do
     {:ok, handle} = image_dump(handle, path)
     handle
   end
 
-  @spec image_dump(image, Path.t) :: {:ok, image} | {:error, reason :: term}
   @doc """
   Saves an image to one or multiple files.
 
   If the attr `:adjoin` is `false`, multiple files will be created and the
   filename is expected to have a printf-formatting sytle (ex.: `foo%0d.png`).
   """
+  @spec image_dump(handle, Path.t) :: {:ok, handle} | exm_error
   def image_dump(handle, path), do: image_dump_file(handle, path)
 
-  @spec image_dump(image) :: {:ok, binary} | {:error, reason :: term}
   @doc """
   Returns the image as a binary. You can change the type of this image
   using the `:magick` attribute.
   """
+  @spec image_dump(handle) :: {:ok, binary} | exm_error
   def image_dump(handle), do: image_dump_blob(handle)
 
-  @spec image_dump!(image) :: binary | {:error, reason :: term}
+  @doc """
+  Refer to `image_dump/1`
+  """
+  @spec image_dump!(handle) :: binary
   def image_dump!(handle) do
     {:ok, blob} = image_dump(handle)
     blob
   end
 
-  @spec image_load_file(image, Path.t) :: {:ok, image} | {:error, reason :: term}
+  @spec image_load_file(handle, Path.t) :: {:ok, handle} | exm_error
   defp image_load_file(_handle, _path), do: fail
 
-  @spec image_load_blob(image, binary) :: {:ok, image} | {:error, reason :: term}
+  @spec image_load_blob(handle, binary) :: {:ok, handle} | exm_error
   defp image_load_blob(_handle, _blob), do: fail
 
-  @spec image_dump_file(image, Path.t) :: {:ok, image} | {:error, reason :: term}
+  @spec image_dump_file(handle, Path.t) :: {:ok, handle} | exm_error
   defp image_dump_file(_handle, _path), do: fail
 
-  @spec image_dump_blob(image) :: {:ok, binary} | {:error, reason :: term}
+  @spec image_dump_blob(handle) :: {:ok, binary} | exm_error
   defp image_dump_blob(_handle), do: fail
 
-  @spec set_attr(image, atom, term) :: {:ok, image} | {:error, reason :: term}
+  @spec set_attr(handle, atom, String.t | boolean) :: {:ok, handle} | exm_error
   defp set_attr(_handle, _attribute, _value), do: fail
 
-  @spec get_attr(image, atom) :: {:ok, attr_value :: term} | {:error, reason :: term}
+  @spec get_attr(handle, atom) :: {:ok, String.t | boolean | non_neg_integer} | exm_error
   defp get_attr(_handle, _attribute), do: fail
 
-  defp fail, do: {:error, "native function"}
+  @docp """
+  this is to fool dialyzer
+  """
+  defp fail, do: ExMagick.Hidden.fail("native function error")
 end

--- a/lib/exmagick/hidden.ex
+++ b/lib/exmagick/hidden.ex
@@ -1,0 +1,7 @@
+defmodule ExMagick.Hidden do
+  @moduledoc false
+
+  @doc false
+  def fail(msg), do: raise msg
+
+end

--- a/mix.exs
+++ b/mix.exs
@@ -25,6 +25,7 @@ defmodule ExMagick.Mixfile do
       package: package,
       deps: deps,
       aliases: aliases,
+      dialyzer: [paths: ["_build/dev/lib/exmagick/ebin/Elixir.ExMagick.beam"]],
       compilers: [:exMagick | Mix.compilers]
     ]
   end
@@ -47,6 +48,7 @@ defmodule ExMagick.Mixfile do
 
   defp deps do
     [
+      {:dialyxir, "~> 0.3.5", only: [:dev]},
       {:earmark, "~> 0.1", only: :dev},
       {:ex_doc, "~> 0.11", only: :dev}
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,10 @@ defmodule ExMagick.Mixfile do
       package: package,
       deps: deps,
       aliases: aliases,
-      dialyzer: [paths: ["_build/dev/lib/exmagick/ebin/Elixir.ExMagick.beam"]],
+      dialyzer: [
+        paths: ["_build/dev/lib/exmagick/ebin/Elixir.ExMagick.beam"],
+        plt_file: System.get_env("DIALYZER_PLT") || ".dialyzer.plt"
+      ],
       compilers: [:exMagick | Mix.compilers]
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,3 @@
-%{"earmark": {:hex, :earmark, "0.1.19", "ffec54f520a11b711532c23d8a52b75a74c09697062d10613fa2dbdf8a9db36e", [:mix], []},
+%{"dialyxir": {:hex, :dialyxir, "0.3.5", "eaba092549e044c76f83165978979f60110dc58dd5b92fd952bf2312f64e9b14", [:mix], []},
+  "earmark": {:hex, :earmark, "0.1.19", "ffec54f520a11b711532c23d8a52b75a74c09697062d10613fa2dbdf8a9db36e", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.11.0", "da23408bf4fb4dec1250cd4785c82f240d05d81ca1c121b075d513f57661452c", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, optional: true]}]}}

--- a/test/exmagick_test.exs
+++ b/test/exmagick_test.exs
@@ -29,6 +29,35 @@ defmodule ExMagickTest do
     assert (File.exists? dst)
   end
 
+  test "magick attr", context do
+    png = Path.join context[:images], "elixir.png"
+    mgk = Enum.random(["PDF", "GIF", "JPEG", "PNG"])
+    exm = ExMagick.init!
+    |> ExMagick.image_load!(png)
+
+    ExMagick.attr!(exm, :magick, mgk)
+    assert mgk == ExMagick.attr!(exm, :magick)
+  end
+
+  test "load from blob", context do
+    png = File.read!(Path.join(context[:images], "elixir.png"))
+    assert "PNG" == ExMagick.init!
+    |> ExMagick.image_load!({:blob, png})
+    |> ExMagick.attr!(:magick)
+  end
+
+  test "load(:png) and write(:blob, :jpg)", context do
+    png = Path.join(context[:images], "elixir.png")
+    jpg = ExMagick.init!
+    |> ExMagick.image_load!(png)
+    |> ExMagick.attr!(:magick, "JPEG")
+    |> ExMagick.image_dump!
+
+    assert "JPEG" == ExMagick.init!
+    |> ExMagick.image_load!({:blob, jpg})
+    |> ExMagick.attr!(:magick)
+  end
+
   test "get image size", %{images: images} do
     src = Path.join images, "elixir.png"
     size = ExMagick.init!


### PR DESCRIPTION
this patch adds support for reading from a binary and writing to binary
which removes the need to use filesystem to query/modify images.

I removed the `@spec` annotations as they don't type-check. nif functions call `fail` which just raise an exception and this makes dialyzer analysis useless.