### PR TITLE
Add [optional] support for dirty scheduler

### DIFF
--- a/lib/c/exmagick.c
+++ b/lib/c/exmagick.c
@@ -22,6 +22,14 @@
 #define EXM_INIT char *errmsg = NULL
 #define EXM_FAIL(j, m) do { errmsg = m; goto j; } while (0)
 
+#ifdef EXM_DIRTY_SCHED
+# define EXM_NIF_IO_BOUND ERL_NIF_DIRTY_JOB_IO_BOUND
+# define EXM_NIF_CPU_BOUND ERL_NIF_DIRTY_JOB_CPU_BOUND
+#else
+# define EXM_NIF_IO_BOUND 0
+# define EXM_NIF_CPU_BOUND 0
+#endif
+
 typedef struct {
   Image *image;
   ImageInfo *i_info;
@@ -51,17 +59,17 @@ static ERL_NIF_TERM exmagick_image_dump_blob (ErlNifEnv *env, int argc, const ER
 
 ErlNifFunc exmagick_interface[] =
 {
-  {"init", 0, exmagick_init_handle},
-  {"image_load_blob", 2, exmagick_image_load_blob},
-  {"image_load_file", 2, exmagick_image_load_file},
-  {"image_dump_file", 2, exmagick_image_dump_file},
-  {"image_dump_blob", 1, exmagick_image_dump_blob},
-  {"set_attr", 3, exmagick_set_attr},
-  {"get_attr", 2, exmagick_get_attr},
-  {"thumb", 3, exmagick_image_thumb},
-  {"size", 3, exmagick_set_size},
-  {"num_pages", 1, exmagick_num_pages},
-  {"crop", 5, exmagick_crop}
+  {"init", 0, exmagick_init_handle, 0},
+  {"image_load_blob", 2, exmagick_image_load_blob, EXM_NIF_CPU_BOUND},
+  {"image_load_file", 2, exmagick_image_load_file, EXM_NIF_CPU_BOUND},
+  {"image_dump_file", 2, exmagick_image_dump_file, EXM_NIF_IO_BOUND},
+  {"image_dump_blob", 1, exmagick_image_dump_blob, EXM_NIF_CPU_BOUND},
+  {"set_attr", 3, exmagick_set_attr, EXM_NIF_CPU_BOUND},
+  {"get_attr", 2, exmagick_get_attr, EXM_NIF_CPU_BOUND},
+  {"thumb", 3, exmagick_image_thumb, EXM_NIF_CPU_BOUND},
+  {"size", 3, exmagick_set_size, EXM_NIF_CPU_BOUND},
+  {"num_pages", 1, exmagick_num_pages, EXM_NIF_CPU_BOUND},
+  {"crop", 5, exmagick_crop, EXM_NIF_CPU_BOUND}
 };
 
 ERL_NIF_INIT(Elixir.ExMagick, exmagick_interface, exmagick_load, NULL, NULL, exmagick_unload)

--- a/lib/exmagick.ex
+++ b/lib/exmagick.ex
@@ -64,9 +64,9 @@ defmodule ExMagick do
   @typedoc """
   An opaque handle used by the GraphicsMagick API
   """
-  @opaque handle  :: binary
+  @opaque handle :: binary
 
-  @type exm_error :: {:error, String.t}
+  @type exm_error :: {:error, String.t()}
 
   @on_load {:load, 0}
 
@@ -75,7 +75,7 @@ defmodule ExMagick do
   def load do
     sofile =
       Path.join([:code.priv_dir(:exmagick), "lib", "libexmagick"])
-      |> String.to_charlist
+      |> String.to_charlist()
 
     :erlang.load_nif(sofile, 0)
   end
@@ -83,7 +83,7 @@ defmodule ExMagick do
   @doc """
   Refer to `attr/3`
   """
-  @spec attr!(handle, :atom, String.t | boolean) :: handle
+  @spec attr!(handle, :atom, String.t() | boolean) :: handle
   def attr!(handle, attribute, value) do
     {:ok, handle} = attr(handle, attribute, value)
     handle
@@ -98,15 +98,18 @@ defmodule ExMagick do
   * `:magick` - the image type [ex.: PNG]
   * `:density` - horizontal and vertical resolution in pixels of this image; [default: 72]
   """
-  @spec attr(handle, :atom, String.t | boolean) :: {:ok, handle} | exm_error
+  @spec attr(handle, :atom, String.t() | boolean) :: {:ok, handle} | exm_error
   def attr(handle, attribute, value) when is_atom(attribute) do
     case attribute do
       :adjoin when is_boolean(value) ->
         set_attr(handle, attribute, value)
+
       :density when is_binary(value) ->
         set_attr(handle, attribute, value)
-      :magick  when is_binary(value) ->
+
+      :magick when is_binary(value) ->
         set_attr(handle, attribute, value)
+
       _ ->
         {:error, "unknown attribute #{attribute}"}
     end
@@ -115,7 +118,7 @@ defmodule ExMagick do
   @doc """
   Refer to `attr/2`
   """
-  @spec attr!(handle, atom) :: String.t | boolean | non_neg_integer
+  @spec attr!(handle, atom) :: String.t() | boolean | non_neg_integer
   def attr!(handle, attribute) do
     {:ok, handle} = attr(handle, attribute)
     handle
@@ -129,14 +132,14 @@ defmodule ExMagick do
   * `:rows` The horizontal size in pixels of the image
   * `:columns` The vertical size in pixels of the image
   """
-  @spec attr(handle, atom) :: {:ok, String.t | boolean | non_neg_integer} | exm_error
+  @spec attr(handle, atom) :: {:ok, String.t() | boolean | non_neg_integer} | exm_error
   def attr(handle, attribute), do: get_attr(handle, attribute)
 
   @doc """
   Computes the number of pages of an image.
   """
   @spec num_pages(handle) :: {:ok, non_neg_integer} | exm_error
-  def num_pages(_handle), do: fail
+  def num_pages(_handle), do: fail()
 
   @doc """
   Refer to `num_pages/1`
@@ -161,10 +164,8 @@ defmodule ExMagick do
   """
   @spec size(handle) :: {:ok, %{width: non_neg_integer, height: non_neg_integer}} | exm_error
   def size(handle) do
-    with \
-      {:ok, width}  <- attr(handle, :columns),
-      {:ok, height} <- attr(handle, :rows)
-    do
+    with {:ok, width} <- attr(handle, :columns),
+         {:ok, height} <- attr(handle, :rows) do
       {:ok, %{width: width, height: height}}
     end
   end
@@ -182,12 +183,13 @@ defmodule ExMagick do
   Resizes the image.
   """
   @spec size(handle, non_neg_integer, non_neg_integer) :: {:ok, handle} | exm_error
-  def size(_handle, _width, _height), do: fail
+  def size(_handle, _width, _height), do: fail()
 
   @doc """
   Refer to `crop/5`.
   """
-  @spec crop!(handle, non_neg_integer, non_neg_integer, non_neg_integer, non_neg_integer) :: handle
+  @spec crop!(handle, non_neg_integer, non_neg_integer, non_neg_integer, non_neg_integer) ::
+          handle
   def crop!(handle, x, y, width, height) do
     {:ok, handle} = crop(handle, x, y, width, height)
     handle
@@ -198,8 +200,9 @@ defmodule ExMagick do
 
   * `x`, `y` refer to starting point, where (0, 0) is top left
   """
-  @spec crop(handle, non_neg_integer, non_neg_integer, non_neg_integer, non_neg_integer) :: {:ok, handle} | exm_error
-  def crop(_handle, _x, _y, _width, _height), do: fail
+  @spec crop(handle, non_neg_integer, non_neg_integer, non_neg_integer, non_neg_integer) ::
+          {:ok, handle} | exm_error
+  def crop(_handle, _x, _y, _width, _height), do: fail()
 
   @spec thumb!(handle, non_neg_integer, non_neg_integer) :: handle
   def thumb!(handle, width, height) do
@@ -214,7 +217,7 @@ defmodule ExMagick do
   concern for speed than resulting image quality._
   """
   @spec thumb(handle, non_neg_integer, non_neg_integer) :: {:ok, handle} | exm_error
-  def thumb(_handle, _width, _height), do: fail
+  def thumb(_handle, _width, _height), do: fail()
 
   @doc false
   def image! do
@@ -224,8 +227,12 @@ defmodule ExMagick do
 
   @doc false
   def image do
-    IO.puts :stderr, "warning: image is deprecated in favor of init." <> Exception.format_stacktrace
-    init
+    IO.puts(
+      :stderr,
+      "warning: image is deprecated in favor of init." <> Exception.format_stacktrace()
+    )
+
+    init()
   end
 
   @doc """
@@ -242,12 +249,12 @@ defmodule ExMagick do
 
   Image attributes may be tuned by using the `attr/3` function.
   """
-  def init, do: fail
+  def init, do: fail()
 
   @doc """
   Refer to `image_load!/2`
   """
-  @spec image_load!(handle, Path.t | {:blob, binary}) :: handle
+  @spec image_load!(handle, Path.t() | {:blob, binary}) :: handle
   def image_load!(handle, path_or_blob) do
     {:ok, handle} = image_load(handle, path_or_blob)
     handle
@@ -257,14 +264,14 @@ defmodule ExMagick do
   Loads an image into the handler. You may provide a file path or a
   tuple `{:blob, ...}` which the second argument is the blob to load.
   """
-  @spec image_load(handle, Path.t | {:blob, binary}) :: {:ok, handle} | exm_error
+  @spec image_load(handle, Path.t() | {:blob, binary}) :: {:ok, handle} | exm_error
   def image_load(handle, {:blob, blob}), do: image_load_blob(handle, blob)
   def image_load(handle, path), do: image_load_file(handle, path)
 
   @doc """
   Refer to `image_dump/2`
   """
-  @spec image_dump!(handle, Path.t) :: handle
+  @spec image_dump!(handle, Path.t()) :: handle
   def image_dump!(handle, path) do
     {:ok, handle} = image_dump(handle, path)
     handle
@@ -276,7 +283,7 @@ defmodule ExMagick do
   If the attr `:adjoin` is `false`, multiple files will be created and the
   filename is expected to have a printf-formatting sytle (ex.: `foo%0d.png`).
   """
-  @spec image_dump(handle, Path.t) :: {:ok, handle} | exm_error
+  @spec image_dump(handle, Path.t()) :: {:ok, handle} | exm_error
   def image_dump(handle, path), do: image_dump_file(handle, path)
 
   @doc """
@@ -295,26 +302,24 @@ defmodule ExMagick do
     blob
   end
 
-  @spec image_load_file(handle, Path.t) :: {:ok, handle} | exm_error
-  defp image_load_file(_handle, _path), do: fail
+  @spec image_load_file(handle, Path.t()) :: {:ok, handle} | exm_error
+  defp image_load_file(_handle, _path), do: fail()
 
   @spec image_load_blob(handle, binary) :: {:ok, handle} | exm_error
-  defp image_load_blob(_handle, _blob), do: fail
+  defp image_load_blob(_handle, _blob), do: fail()
 
-  @spec image_dump_file(handle, Path.t) :: {:ok, handle} | exm_error
-  defp image_dump_file(_handle, _path), do: fail
+  @spec image_dump_file(handle, Path.t()) :: {:ok, handle} | exm_error
+  defp image_dump_file(_handle, _path), do: fail()
 
   @spec image_dump_blob(handle) :: {:ok, binary} | exm_error
-  defp image_dump_blob(_handle), do: fail
+  defp image_dump_blob(_handle), do: fail()
 
-  @spec set_attr(handle, atom, String.t | boolean) :: {:ok, handle} | exm_error
-  defp set_attr(_handle, _attribute, _value), do: fail
+  @spec set_attr(handle, atom, String.t() | boolean) :: {:ok, handle} | exm_error
+  defp set_attr(_handle, _attribute, _value), do: fail()
 
-  @spec get_attr(handle, atom) :: {:ok, String.t | boolean | non_neg_integer} | exm_error
-  defp get_attr(_handle, _attribute), do: fail
+  @spec get_attr(handle, atom) :: {:ok, String.t() | boolean | non_neg_integer} | exm_error
+  defp get_attr(_handle, _attribute), do: fail()
 
-  @docp """
-  this is to fool dialyzer
-  """
+  # XXX: this is to fool dialyzer
   defp fail, do: ExMagick.Hidden.fail("native function error")
 end

--- a/lib/exmagick.ex
+++ b/lib/exmagick.ex
@@ -13,7 +13,8 @@
 
 defmodule ExMagick do
   @moduledoc """
-  NIF bindings to the GraphicsMagick API.
+  NIF bindings to the GraphicsMagick API with optional support for
+  dirty scheduling.
 
   ## Examples
 
@@ -73,11 +74,17 @@ defmodule ExMagick do
   @doc false
   @spec load :: :ok | {:error, {atom, charlist}}
   def load do
-    sofile =
-      Path.join([:code.priv_dir(:exmagick), "lib", "libexmagick"])
+    nd_file =
+      Path.join([:code.priv_dir(:exmagick), "lib/libexmagick_nd"])
       |> String.to_charlist()
 
-    :erlang.load_nif(sofile, 0)
+    d_file =
+      Path.join([:code.priv_dir(:exmagick), "lib/libexmagick_d"])
+      |> String.to_charlist()
+
+    with {:error, {:notsup, _}} <- :erlang.load_nif(d_file, 0) do
+      :erlang.load_nif(nd_file, 0)
+    end
   end
 
   @doc """

--- a/lib/exmagick/hidden.ex
+++ b/lib/exmagick/hidden.ex
@@ -2,6 +2,5 @@ defmodule ExMagick.Hidden do
   @moduledoc false
 
   @doc false
-  def fail(msg), do: raise msg
-
+  def fail(msg), do: raise(msg)
 end

--- a/mix.exs
+++ b/mix.exs
@@ -3,11 +3,27 @@ defmodule Mix.Tasks.Compile.ExMagick do
 
   @shortdoc "compiles the exmagick library"
   def run(_) do
-    distroot  = Path.absname (Path.expand "priv", __DIR__)
-    buildroot = Mix.Project.build_path
-    runcmd("make", ["--quiet", "distroot=#{distroot}", "buildroot=#{buildroot}", "compile", "install"])
-    runcmd("make", ["--quiet", "dirty_sched=on", "distroot=#{distroot}", "buildroot=#{buildroot}", "compile", "install"])
-    Mix.Project.build_structure
+    distroot = Path.absname(Path.expand("priv", __DIR__))
+    buildroot = Mix.Project.build_path()
+
+    runcmd("make", [
+      "--quiet",
+      "distroot=#{distroot}",
+      "buildroot=#{buildroot}",
+      "compile",
+      "install"
+    ])
+
+    runcmd("make", [
+      "--quiet",
+      "dirty_sched=on",
+      "distroot=#{distroot}",
+      "buildroot=#{buildroot}",
+      "compile",
+      "install"
+    ])
+
+    Mix.Project.build_structure()
   end
 
   defp runcmd(cmd, args) do
@@ -19,18 +35,19 @@ defmodule ExMagick.Mixfile do
   use Mix.Project
 
   def project do
-    [ app: :exmagick,
+    [
+      app: :exmagick,
       version: "0.0.5",
       elixir: "~> 1.2",
-      description: description,
-      package: package,
-      deps: deps,
-      aliases: aliases,
+      description: description(),
+      package: package(),
+      deps: deps(),
+      aliases: aliases(),
       dialyzer: [
         paths: ["_build/dev/lib/exmagick/ebin/Elixir.ExMagick.beam"],
         plt_file: System.get_env("DIALYZER_PLT") || ".dialyzer.plt"
       ],
-      compilers: [:exMagick | Mix.compilers]
+      compilers: [:exMagick | Mix.compilers()]
     ]
   end
 
@@ -63,12 +80,19 @@ defmodule ExMagick.Mixfile do
   end
 
   defp make_clean(_) do
-    File.rm_rf "priv"
-    build_dir = Path.dirname Mix.Project.build_path
-    if File.exists? build_dir do
+    File.rm_rf("priv")
+    build_dir = Path.dirname(Mix.Project.build_path())
+
+    if File.exists?(build_dir) do
       for env <- File.ls!(build_dir) do
-        buildroot = Path.join build_dir, env
-        {_, 0} = System.cmd("make", ["buildroot=#{buildroot}", "clean", "--quiet"], into: IO.stream(:stdio, :line))
+        buildroot = Path.join(build_dir, env)
+
+        {_, 0} =
+          System.cmd(
+            "make",
+            ["buildroot=#{buildroot}", "clean", "--quiet"],
+            into: IO.stream(:stdio, :line)
+          )
       end
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -6,6 +6,7 @@ defmodule Mix.Tasks.Compile.ExMagick do
     distroot  = Path.absname (Path.expand "priv", __DIR__)
     buildroot = Mix.Project.build_path
     runcmd("make", ["--quiet", "distroot=#{distroot}", "buildroot=#{buildroot}", "compile", "install"])
+    runcmd("make", ["--quiet", "dirty_sched=on", "distroot=#{distroot}", "buildroot=#{buildroot}", "compile", "install"])
     Mix.Project.build_structure
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -37,7 +37,7 @@ defmodule ExMagick.Mixfile do
   def project do
     [
       app: :exmagick,
-      version: "0.0.5",
+      version: "1.0.0",
       elixir: "~> 1.2",
       description: description(),
       package: package(),

--- a/test/exmagick_test.exs
+++ b/test/exmagick_test.exs
@@ -2,17 +2,21 @@ defmodule ExMagickTest do
   use ExUnit.Case, async: true
 
   setup do
-    tmpdir = Enum.reduce_while(0..100, nil, fn _, _ ->
-      rand = :erlang.unique_integer([:positive])
-      path = Path.join System.tmp_dir!, "#{rand}"
-      case (File.mkdir path) do
-        :ok -> {:halt, path}
-        _   -> {:cont, nil}
-      end
+    tmpdir =
+      Enum.reduce_while(0..100, nil, fn _, _ ->
+        rand = :erlang.unique_integer([:positive])
+        path = Path.join(System.tmp_dir!(), "#{rand}")
+
+        case File.mkdir(path) do
+          :ok -> {:halt, path}
+          _ -> {:cont, nil}
+        end
+      end)
+
+    on_exit(fn ->
+      File.rm_rf!(tmpdir)
     end)
-    on_exit fn ->
-      File.rm_rf! tmpdir
-    end
+
     {:ok, [tmpdir: tmpdir]}
   end
 
@@ -21,21 +25,23 @@ defmodule ExMagickTest do
   end
 
   test "image_load(:png) and image_save(:jpg)", context do
-    src = Path.join context[:images], "elixir.png"
-    dst = Path.join context[:tmpdir], "elixir.jpg"
+    src = Path.join(context[:images], "elixir.png")
+    dst = Path.join(context[:tmpdir], "elixir.jpg")
 
-    ExMagick.init!
+    ExMagick.init!()
     |> ExMagick.image_load!(src)
     |> ExMagick.image_dump!(dst)
 
-    assert (File.exists? dst)
+    assert File.exists?(dst)
   end
 
   test "magick attr", context do
-    png = Path.join context[:images], "elixir.png"
+    png = Path.join(context[:images], "elixir.png")
     mgk = Enum.random(["PDF", "GIF", "JPEG", "PNG"])
-    exm = ExMagick.init!
-    |> ExMagick.image_load!(png)
+
+    exm =
+      ExMagick.init!()
+      |> ExMagick.image_load!(png)
 
     ExMagick.attr!(exm, :magick, mgk)
     assert mgk == ExMagick.attr!(exm, :magick)
@@ -44,164 +50,184 @@ defmodule ExMagickTest do
   test "load from blob", context do
     png = File.read!(Path.join(context[:images], "elixir.png"))
 
-    assert "PNG" == ExMagick.init!
-    |> ExMagick.image_load!({:blob, png})
-    |> ExMagick.attr!(:magick)
+    assert "PNG" ==
+             ExMagick.init!()
+             |> ExMagick.image_load!({:blob, png})
+             |> ExMagick.attr!(:magick)
   end
 
   test "load(:png) and write(:blob, :jpg)", context do
     png = Path.join(context[:images], "elixir.png")
-    jpg = ExMagick.init!
-    |> ExMagick.image_load!(png)
-    |> ExMagick.attr!(:magick, "JPEG")
-    |> ExMagick.image_dump!
 
-    assert "JPEG" == ExMagick.init!
-    |> ExMagick.image_load!({:blob, jpg})
-    |> ExMagick.attr!(:magick)
+    jpg =
+      ExMagick.init!()
+      |> ExMagick.image_load!(png)
+      |> ExMagick.attr!(:magick, "JPEG")
+      |> ExMagick.image_dump!()
+
+    assert "JPEG" ==
+             ExMagick.init!()
+             |> ExMagick.image_load!({:blob, jpg})
+             |> ExMagick.attr!(:magick)
   end
 
   test "get image size", %{images: images} do
-    src = Path.join images, "elixir.png"
-    size = ExMagick.init!
-    |> ExMagick.image_load!(src)
-    |> ExMagick.size!
+    src = Path.join(images, "elixir.png")
+
+    size =
+      ExMagick.init!()
+      |> ExMagick.image_load!(src)
+      |> ExMagick.size!()
 
     assert %{width: w, height: h} = size
     assert 227 == w
-    assert  95 == h
+    assert 95 == h
   end
 
   test "resizes an image", %{images: images} do
-    src = Path.join images, "elixir.png"
-    image = ExMagick.init!
-    |> ExMagick.image_load!(src)
+    src = Path.join(images, "elixir.png")
+
+    image =
+      ExMagick.init!()
+      |> ExMagick.image_load!(src)
 
     assert %{width: 227, height: 95} == ExMagick.size!(image)
 
-    new_size = image
-    |> ExMagick.size!(100, 42)
-    |> ExMagick.size!
+    new_size =
+      image
+      |> ExMagick.size!(100, 42)
+      |> ExMagick.size!()
 
     assert %{width: 100, height: 42} == new_size
   end
 
   test "thumbnails an image", %{images: images} do
-    src = Path.join images, "elixir.png"
-    image = ExMagick.init!
-    |> ExMagick.image_load!(src)
+    src = Path.join(images, "elixir.png")
+
+    image =
+      ExMagick.init!()
+      |> ExMagick.image_load!(src)
 
     assert %{width: 227, height: 95} == ExMagick.size!(image)
 
-    new_size = image
-    |> ExMagick.thumb!(42, 42)
-    |> ExMagick.size!
+    new_size =
+      image
+      |> ExMagick.thumb!(42, 42)
+      |> ExMagick.size!()
 
     assert %{width: 42, height: 42} == new_size
   end
 
   test "resizes and saves image", %{images: images, tmpdir: tmpdir} do
-    src = Path.join images, "elixir.png"
-    dst = Path.join tmpdir, "resized.png"
+    src = Path.join(images, "elixir.png")
+    dst = Path.join(tmpdir, "resized.png")
 
-    size = ExMagick.init!
-    |> ExMagick.image_load!(src)
-    |> ExMagick.size!(100, 42)
-    |> ExMagick.image_dump!(dst)
-    |> ExMagick.image_load!(dst)
-    |> ExMagick.size!
+    size =
+      ExMagick.init!()
+      |> ExMagick.image_load!(src)
+      |> ExMagick.size!(100, 42)
+      |> ExMagick.image_dump!(dst)
+      |> ExMagick.image_load!(dst)
+      |> ExMagick.size!()
 
     assert %{width: 100, height: 42} == size
   end
 
   test "crops image", %{images: images, tmpdir: tmpdir} do
-    src = Path.join images, "elixir.png"
-    dst = Path.join tmpdir, "cropped.png"
+    src = Path.join(images, "elixir.png")
+    dst = Path.join(tmpdir, "cropped.png")
 
-    size = ExMagick.init!
-    |> ExMagick.image_load!(src)
-    |> ExMagick.crop!(0,0, 100, 10)
-    |> ExMagick.image_dump!(dst)
-    |> ExMagick.image_load!(dst)
-    |> ExMagick.size!
+    size =
+      ExMagick.init!()
+      |> ExMagick.image_load!(src)
+      |> ExMagick.crop!(0, 0, 100, 10)
+      |> ExMagick.image_dump!(dst)
+      |> ExMagick.image_load!(dst)
+      |> ExMagick.size!()
 
     assert %{width: 100, height: 10} == size
   end
 
   test "load PDF with density", %{images: images} do
-    src = Path.join images, "elixir.pdf"
+    src = Path.join(images, "elixir.pdf")
 
-    image = ExMagick.init!
-    |> ExMagick.image_load!(src)
+    image =
+      ExMagick.init!()
+      |> ExMagick.image_load!(src)
 
     assert %{width: 227, height: 95} == ExMagick.size!(image)
 
-    size_with_density = ExMagick.init!
-    |> ExMagick.attr!(:density, "300")
-    |> ExMagick.image_load!(src)
-    |> ExMagick.size!
+    size_with_density =
+      ExMagick.init!()
+      |> ExMagick.attr!(:density, "300")
+      |> ExMagick.image_load!(src)
+      |> ExMagick.size!()
 
     assert %{width: 946, height: 396} == size_with_density
   end
 
   test "adjoin attribute" do
-    value = ExMagick.init! |> ExMagick.attr(:adjoin)
+    value = ExMagick.init!() |> ExMagick.attr(:adjoin)
 
     assert {:ok, true} == value
   end
 
   test "magick attribute", context do
-    for {type, path} <- [ {"PDF", (Path.join context[:images], "elixir.pdf")},
-                          {"PNG", (Path.join context[:images], "elixir.png")}
-                        ] do
-      value = ExMagick.init!
-      |> ExMagick.image_load!(path)
-      |> ExMagick.attr!(:magick)
+    for {type, path} <- [
+          {"PDF", Path.join(context[:images], "elixir.pdf")},
+          {"PNG", Path.join(context[:images], "elixir.png")}
+        ] do
+      value =
+        ExMagick.init!()
+        |> ExMagick.image_load!(path)
+        |> ExMagick.attr!(:magick)
 
       assert type == value
     end
   end
 
   test "image_load(:pdf) and image_save(:jpg)", context do
-    src = Path.join context[:images], "elixir.pdf"
-    dst = Path.join context[:tmpdir], "elixir.jpg"
+    src = Path.join(context[:images], "elixir.pdf")
+    dst = Path.join(context[:tmpdir], "elixir.jpg")
 
-    ExMagick.init!
+    ExMagick.init!()
     |> ExMagick.image_load!(src)
     |> ExMagick.image_dump!(dst)
 
-    assert (File.exists? dst)
+    assert File.exists?(dst)
   end
 
   test "image_load(:pdf) and image_save([:jpg])", context do
-    src = Path.join context[:images], "elixir.pdf"
-    dst = Path.join context[:tmpdir], "elixir%0d.jpg"
+    src = Path.join(context[:images], "elixir.pdf")
+    dst = Path.join(context[:tmpdir], "elixir%0d.jpg")
 
-    ExMagick.init!
+    ExMagick.init!()
     |> ExMagick.image_load!(src)
     |> ExMagick.attr!(:adjoin, false)
     |> ExMagick.image_dump!(dst)
 
-    refute (File.exists? dst)
-    assert 10 == length(File.ls! context[:tmpdir])
+    refute File.exists?(dst)
+    assert 10 == length(File.ls!(context[:tmpdir]))
   end
 
   test "num_pages counts pages, multi page pdf", context do
-    src = Path.join context[:images], "elixir.pdf"
+    src = Path.join(context[:images], "elixir.pdf")
 
-    num_pages = ExMagick.init!
-    |> ExMagick.image_load!(src)
-    |> ExMagick.num_pages!
+    num_pages =
+      ExMagick.init!()
+      |> ExMagick.image_load!(src)
+      |> ExMagick.num_pages!()
 
     assert 10 == num_pages
   end
 
   test "num_pages counts pages, png", context do
-    src = Path.join context[:images], "elixir.png"
+    src = Path.join(context[:images], "elixir.png")
 
-    num_pages = ExMagick.init!
-    |> ExMagick.image_load!(src)
-    |> ExMagick.num_pages!
+    num_pages =
+      ExMagick.init!()
+      |> ExMagick.image_load!(src)
+      |> ExMagick.num_pages!()
 
     assert 1 == num_pages
   end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,1 @@
-ExUnit.start
+ExUnit.start()


### PR DESCRIPTION
Compiles two libraries, one of them with dirty scheduling flags enabled and chooses which one to use depending on the runtime capabilities.