### PR TITLE
bugfix: memory leak in ImageToBlob

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,23 +7,28 @@ addons:
       - ghostscript
       - libgraphicsmagick1-dev
 elixir:
-  - 1.3
   - 1.4
   - 1.5
   - 1.6
 otp_release:
-  - 19.3
   - 20.0
   - 20.1
   - 20.2
   - 20.3
+env:
+  - exm_dirty_sched=no
+  - exm_dirty_sched=auto
 matrix:
-  exclude:
+  include:
     - elixir: 1.3
-      otp_release: 20.0
+      otp_release: 19.0
+      env: exm_dirty_sched=no
     - elixir: 1.3
-      otp_release: 20.1
+      otp_release: 19.1
+      env: exm_dirty_sched=no
     - elixir: 1.3
-      otp_release: 20.2
+      otp_release: 19.2
+      env: exm_dirty_sched=no
     - elixir: 1.3
-      otp_release: 20.3
+      otp_release: 19.3
+      env: exm_dirty_sched=no

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+sudo: false
+language: elixir
+addons:
+  apt:
+    packages:
+      - libtool
+      - ghostscript
+      - libgraphicsmagick1-dev
+elixir:
+  - 1.3
+  - 1.4
+  - 1.5
+  - 1.6
+otp_release:
+  - 19.3
+  - 20.0
+  - 20.1
+  - 20.2
+  - 20.3
+matrix:
+  exclude:
+    - elixir: 1.3
+      otp_release: 20.0
+    - elixir: 1.3
+      otp_release: 20.1
+    - elixir: 1.3
+      otp_release: 20.2
+    - elixir: 1.3
+      otp_release: 20.3

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,12 @@
 -*- mode: text -*-
 
+v0.0.6
+  * add optional dirty scheduler support;
+  * bugfix: memory leak on `image_dump/1`
+
+v0.0.5
+  * add num_pages
+
 v0.0.4
   * dump and load using binaries
   * magick attribute is read-write

--- a/README.md
+++ b/README.md
@@ -47,6 +47,20 @@ If you have all dependencies satisfied then the following should pass:
 $ mix test
 ```
 
+DIRTY SCHEDULER
+---------------
+
+The library has support for using dirty scheduler but it is disabled
+by default. To enable it, define an environment variable before
+compiling:
+
+```
+$ env exm_dirty_sched=auto mix compile
+```
+
+It will enable dirty scheduler support when the machine provides
+support for it.
+
 LINKS
 -----
 

--- a/bin/check_dirty_sched.sh
+++ b/bin/check_dirty_sched.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+set -e
+
+exec 1>/dev/null
+exec 2>/dev/null
+
+make_test () {
+  echo '
+  #include "erl_nif.h"
+  int main () {
+    int x = ERL_NIF_DIRTY_JOB_CPU_BOUND;
+    return 0;
+  }
+  '
+}
+
+tempfile=$(mktemp "XXXXXXXX.c") && {
+  trap 'rm -f "$tempfile"' EXIT
+
+  make_test >"$tempfile"
+  $CC $CFLAGS -c "$tempfile" -o/dev/null
+}

--- a/bin/erlang_include_dir.exs
+++ b/bin/erlang_include_dir.exs
@@ -1,0 +1,5 @@
+#!/usr/bin/env elixir
+
+[:code.root_dir(), ["erts-", :erlang.system_info(:version)], "include"]
+|> Path.join()
+|> IO.puts()

--- a/lib/c/exmagick.c
+++ b/lib/c/exmagick.c
@@ -22,14 +22,6 @@
 #define EXM_INIT char *errmsg = NULL
 #define EXM_FAIL(j, m) do { errmsg = m; goto j; } while (0)
 
-#ifdef EXM_DIRTY_SCHED
-# define EXM_NIF_IO_BOUND ERL_NIF_DIRTY_JOB_IO_BOUND
-# define EXM_NIF_CPU_BOUND ERL_NIF_DIRTY_JOB_CPU_BOUND
-#else
-# define EXM_NIF_IO_BOUND 0
-# define EXM_NIF_CPU_BOUND 0
-#endif
-
 typedef struct {
   Image *image;
   ImageInfo *i_info;
@@ -57,20 +49,37 @@ static ERL_NIF_TERM exmagick_image_load_blob (ErlNifEnv *env, int argc, const ER
 static ERL_NIF_TERM exmagick_image_dump_file (ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]);
 static ERL_NIF_TERM exmagick_image_dump_blob (ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]);
 
+#ifdef EXM_NO_DIRTY_SCHED
+ErlNifFunc exmagick_interface[] =
+{
+  {"init", 0, exmagick_init_handle},
+  {"image_load_blob", 2, exmagick_image_load_blob},
+  {"image_load_file", 2, exmagick_image_load_file},
+  {"image_dump_file", 2, exmagick_image_dump_file},
+  {"image_dump_blob", 1, exmagick_image_dump_blob},
+  {"set_attr", 3, exmagick_set_attr},
+  {"get_attr", 2, exmagick_get_attr},
+  {"thumb", 3, exmagick_image_thumb},
+  {"size", 3, exmagick_set_size},
+  {"num_pages", 1, exmagick_num_pages},
+  {"crop", 5, exmagick_crop}
+};
+#else
 ErlNifFunc exmagick_interface[] =
 {
   {"init", 0, exmagick_init_handle, 0},
-  {"image_load_blob", 2, exmagick_image_load_blob, EXM_NIF_CPU_BOUND},
-  {"image_load_file", 2, exmagick_image_load_file, EXM_NIF_CPU_BOUND},
-  {"image_dump_file", 2, exmagick_image_dump_file, EXM_NIF_IO_BOUND},
-  {"image_dump_blob", 1, exmagick_image_dump_blob, EXM_NIF_CPU_BOUND},
-  {"set_attr", 3, exmagick_set_attr, EXM_NIF_CPU_BOUND},
-  {"get_attr", 2, exmagick_get_attr, EXM_NIF_CPU_BOUND},
-  {"thumb", 3, exmagick_image_thumb, EXM_NIF_CPU_BOUND},
-  {"size", 3, exmagick_set_size, EXM_NIF_CPU_BOUND},
-  {"num_pages", 1, exmagick_num_pages, EXM_NIF_CPU_BOUND},
-  {"crop", 5, exmagick_crop, EXM_NIF_CPU_BOUND}
+  {"image_load_blob", 2, exmagick_image_load_blob, ERL_NIF_DIRTY_JOB_CPU_BOUND},
+  {"image_load_file", 2, exmagick_image_load_file, ERL_NIF_DIRTY_JOB_CPU_BOUND},
+  {"image_dump_file", 2, exmagick_image_dump_file, ERL_NIF_DIRTY_JOB_CPU_BOUND},
+  {"image_dump_blob", 1, exmagick_image_dump_blob, ERL_NIF_DIRTY_JOB_CPU_BOUND},
+  {"set_attr", 3, exmagick_set_attr, ERL_NIF_DIRTY_JOB_CPU_BOUND},
+  {"get_attr", 2, exmagick_get_attr, ERL_NIF_DIRTY_JOB_CPU_BOUND},
+  {"thumb", 3, exmagick_image_thumb, ERL_NIF_DIRTY_JOB_CPU_BOUND},
+  {"size", 3, exmagick_set_size, ERL_NIF_DIRTY_JOB_CPU_BOUND},
+  {"num_pages", 1, exmagick_num_pages, ERL_NIF_DIRTY_JOB_CPU_BOUND},
+  {"crop", 5, exmagick_crop, ERL_NIF_DIRTY_JOB_CPU_BOUND}
 };
+#endif
 
 ERL_NIF_INIT(Elixir.ExMagick, exmagick_interface, exmagick_load, NULL, NULL, exmagick_unload)
 

--- a/lib/exmagick.ex
+++ b/lib/exmagick.ex
@@ -74,7 +74,8 @@ defmodule ExMagick do
   @doc false
   @spec load :: :ok | {:error, {atom, charlist}}
   def load do
-    Path.join([:code.priv_dir(:exmagick), "lib/libexmagick"])
+    [:code.priv_dir(:exmagick), "lib/libexmagick"]
+    |> Path.join()
     |> String.to_charlist()
     |> :erlang.load_nif(0)
   end

--- a/lib/exmagick.ex
+++ b/lib/exmagick.ex
@@ -74,17 +74,9 @@ defmodule ExMagick do
   @doc false
   @spec load :: :ok | {:error, {atom, charlist}}
   def load do
-    nd_file =
-      Path.join([:code.priv_dir(:exmagick), "lib/libexmagick_nd"])
-      |> String.to_charlist()
-
-    d_file =
-      Path.join([:code.priv_dir(:exmagick), "lib/libexmagick_d"])
-      |> String.to_charlist()
-
-    with {:error, {:notsup, _}} <- :erlang.load_nif(d_file, 0) do
-      :erlang.load_nif(nd_file, 0)
-    end
+    Path.join([:code.priv_dir(:exmagick), "lib/libexmagick"])
+    |> String.to_charlist()
+    |> :erlang.load_nif(0)
   end
 
   @doc """

--- a/makefile
+++ b/makefile
@@ -12,38 +12,29 @@ else
 bin_libtool     ?= libtool
 endif
 
-gm_libs      	:= $(shell $(bin_gmconfig) --libs)
-gm_cflags    	:= $(shell $(bin_gmconfig) --cflags --cppflags)
-gm_ldflags   	:= $(shell $(bin_gmconfig) --ldflags)
-erlang_flags 	:= $(shell $(bin_elixir) -e 'IO.puts (Path.join [:code.root_dir, ["erts-", :erlang.system_info(:version)], "include"])')
+gm_libs               := $(shell $(bin_gmconfig) --libs)
+gm_cflags             := $(shell $(bin_gmconfig) --cflags --cppflags)
+gm_ldflags            := $(shell $(bin_gmconfig) --ldflags)
+erl_cflags            := -I$(shell $(bin_elixir) $(CURDIR)/bin/erlang_include_dir.exs)
+erl_dirty_sched_flags := $(shell env CC=$(CC) CFLAGS=$(erl_cflags) $(CURDIR)/bin/check_dirty_sched.sh || echo -DEXM_NO_DIRTY_SCHED)
 
 exmagick_rpath  := $(shell $(CURDIR)/bin/rpath.sh $(gm_ldflags))
-exmagick_cflags  = -pedantic -ansi -I$(erlang_flags) $(gm_cflags)
+exmagick_cflags  = -pedantic -ansi $(erl_cflags) $(gm_cflags) $(erl_dirty_sched_flags)
 exmagick_ldflags = $(gm_ldflags) -rpath $(exmagick_rpath) -L/usr/local/lib
 exmagick_ld_libs = $(gm_libs)
 
-srcfiles    = $(wildcard lib/c/*.c)
-objfiles_d  = $(addprefix $(buildroot)/, $(addsuffix _d.lo, $(basename $(srcfiles))))
-objfiles_nd = $(addprefix $(buildroot)/, $(addsuffix _nd.lo, $(basename $(srcfiles))))
+srcfiles  = $(wildcard lib/c/*.c)
+objfiles  = $(addprefix $(buildroot)/, $(addsuffix .lo, $(basename $(srcfiles))))
 
-libfile  = $(buildroot)/$(libname).la
-
-ifdef dirty_sched
-libname  = libexmagick_d
-objfiles = $(objfiles_d)
-else
-libname  = libexmagick_nd
-objfiles = $(objfiles_nd)
-endif
+libname = libexmagick
+libfile = $(buildroot)/$(libname).la
 
 build: $(libfile)
 compile: build
 
 clean:
-	$(bin_libtool) --mode=clean rm -f $(objfiles_d)
-	$(bin_libtool) --mode=clean rm -f $(objfiles_nd)
-	$(bin_libtool) --mode=clean rm -f $(libfile_d)
-	$(bin_libtool) --mode=clean rm -f $(libfile_nd)
+	$(bin_libtool) --mode=clean rm -f $(libfile)
+	$(bin_libtool) --mode=clean rm -f $(objfiles)
 
 install: $(distroot)/lib/$(libname).la
 
@@ -56,11 +47,7 @@ $(distroot)/lib/$(libname).la: $(libfile)
 	  then ln -s $(libname).dylib $(@D)/$(libname).so; fi;\
 	fi
 
-$(buildroot)/%_d.lo: %.c
-	test -d $(@D) || mkdir -p $(@D)
-	$(bin_libtool) --tag=CC --mode=compile $(CC) -DEXM_DIRTY_SCHED $(CFLAGS) $(exmagick_cflags) -c $(<) -o $(@)
-
-$(buildroot)/%_nd.lo: %.c
+$(buildroot)/%.lo: %.c
 	test -d $(@D) || mkdir -p $(@D)
 	$(bin_libtool) --tag=CC --mode=compile $(CC) $(CFLAGS) $(exmagick_cflags) -c $(<) -o $(@)
 

--- a/makefile
+++ b/makefile
@@ -1,3 +1,5 @@
+exm_dirty_sched ?= no
+
 uname_s         := $(shell sh -c 'uname -s 2>/dev/null || echo undefined')
 
 distroot        ?= $(CURDIR)/priv
@@ -16,7 +18,11 @@ gm_libs               := $(shell $(bin_gmconfig) --libs)
 gm_cflags             := $(shell $(bin_gmconfig) --cflags --cppflags)
 gm_ldflags            := $(shell $(bin_gmconfig) --ldflags)
 erl_cflags            := -I$(shell $(bin_elixir) $(CURDIR)/bin/erlang_include_dir.exs)
+ifeq ($(exm_dirty_sched),no)
+erl_dirty_sched_flags := -DEXM_NO_DIRTY_SCHED
+else
 erl_dirty_sched_flags := $(shell env CC=$(CC) CFLAGS=$(erl_cflags) $(CURDIR)/bin/check_dirty_sched.sh || echo -DEXM_NO_DIRTY_SCHED)
+endif
 
 exmagick_rpath  := $(shell $(CURDIR)/bin/rpath.sh $(gm_ldflags))
 exmagick_cflags  = -pedantic -ansi $(erl_cflags) $(gm_cflags) $(erl_dirty_sched_flags)

--- a/mix.exs
+++ b/mix.exs
@@ -29,7 +29,7 @@ defmodule ExMagick.Mixfile do
     [
       app: :exmagick,
       version: "1.0.0",
-      elixir: "~> 1.2",
+      elixir: "~> 1.3",
       description: description(),
       package: package(),
       deps: deps(),

--- a/mix.exs
+++ b/mix.exs
@@ -14,15 +14,6 @@ defmodule Mix.Tasks.Compile.ExMagick do
       "install"
     ])
 
-    runcmd("make", [
-      "--quiet",
-      "dirty_sched=on",
-      "distroot=#{distroot}",
-      "buildroot=#{buildroot}",
-      "compile",
-      "install"
-    ])
-
     Mix.Project.build_structure()
   end
 


### PR DESCRIPTION
fixes #9 

image_dump!/1 is leaking memory because we are not deallocating memory
after `ImageToBlob`. the following script should exhaust the machine's
memory after a short while:

    ```
    defmodule Loop do
      def loop() do
        ExMagick.init!()
        |> ExMagick.image_load!("/tmp/foobar.tiff") # 16MB file
        |> ExMagick.image_dump!()
        loop()
      end
    end
    Loop.loop()
    ```

the solution is to copy the blob into a new new managed binary. this
might impact performance a bit depending on the size of the image but as far
as we know this can't be helped. it seems there is no way to attach a
destructor to a nif term other than `enif_open_resource_type` which
can't occur outside of `load` or `upgrade`.